### PR TITLE
Add IDL test files, update tests to handle automaticall test against those files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build and package vsix
         run: yarn package
 
-      # - name: Test parser
-      #   run: npx mocha server/out/test/index.js
+      - name: Test parser
+        run: npx mocha server/out/test/index.js
 
       - name: Upload VSIX
         uses: actions/upload-artifact@v2.2.4

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"watch": "tsc -b -w",
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
 		"test": "pwsh ./scripts/e2e.ps1",
-		"test:parser": "npx mocha server/out/test/index.js",
+		"test:parser": "npm run build && npx mocha server/out/test/index.js",
 		"package": "vsce package"
 	},
 	"devDependencies": {

--- a/server/src/test/assets/class_with_attributes.idl
+++ b/server/src/test/assets/class_with_attributes.idl
@@ -1,5 +1,5 @@
-namespace DemoNamespace{
-
+namespace DemoNamespace
+{
 	[PREVIEW_API]
 	[webhosthidden]
 	unsealed runtimeclass AttributedClass

--- a/server/src/test/assets/class_with_attributes.idl
+++ b/server/src/test/assets/class_with_attributes.idl
@@ -1,0 +1,18 @@
+namespace DemoNamespace{
+
+	[PREVIEW_API]
+	[webhosthidden]
+	unsealed runtimeclass AttributedClass
+	{
+		AttributedClass();
+
+		[PROPERTY_CHANGED_CALLBACK]
+		[IS_AWESOME_PROPERTY]
+		Object Param{ get; set; };
+
+		[PROPERTY_CHANGED_CALLBACK_DISABLED]
+		[IS_AWESOME_PROPERTY]
+		[IS_PRIVATE]
+		DemoNamespace.DemoClass DemoClass{ get; set; }
+	}
+}

--- a/server/src/test/assets/enum.idl
+++ b/server/src/test/assets/enum.idl
@@ -1,0 +1,7 @@
+namespace DemoNamespace{
+	enum DemoEnum
+	{
+		IsThisEnum,
+		ThisIsEnum
+	};
+}

--- a/server/src/test/assets/enum.idl
+++ b/server/src/test/assets/enum.idl
@@ -1,7 +1,8 @@
-namespace DemoNamespace{
+namespace DemoNamespace
+{
 	enum DemoEnum
 	{
 		IsThisEnum,
 		ThisIsEnum
-	};
+	}
 }

--- a/server/src/test/assets/large_demo_class.idl
+++ b/server/src/test/assets/large_demo_class.idl
@@ -1,45 +1,46 @@
-namespace DemoNamespace{
+namespace DemoNamespace
+{
 
 	[PUBLIC_API]
 	[webhosthidden]
 	unsealed runtimeclass CoolClass : DemoNamespace.BaseClass
 	{
-			CoolClass();
+		CoolClass();
 
-			// This should always return true...
-			Boolean IsCool{ get; };
+		// This should always return true...
+		Boolean IsCool{ get; };
 
-			[REQUIRE_NON_NULL]
-			CoolDemoNamespace.TemplateEngine TemplateEngine{ get; set; };
-			[REQUIRE_NON_NULL]
-			CoolDemoNamespace.Hashcode Hashcode{ get; set; };
-	
-			[PROPERTY_CHANGED_CALLBACK]
-			Boolean HasDoneClassyThings{ get; set; };
-	
-			[DEFAULT_VALUE("DemoNamespace.CoolClass")]
-			[MUX_PROPERTY_CHANGED_CALLBACK]
-			String ObjectName{ get; set; };
+		[REQUIRE_NON_NULL]
+		CoolDemoNamespace.TemplateEngine TemplateEngine{ get; set; };
+		[REQUIRE_NON_NULL]
+		CoolDemoNamespace.Hashcode Hashcode{ get; set; };
 
-			event DemoNamespace.ValueChangedHandler<CoolClass, CoolClassNameChangedEventArgs> NameChanged;
-	
-			static String NamespaceAlias{ get; };
-			static String ClassNameAlias{ get; };
+		[PROPERTY_CHANGED_CALLBACK]
+		Boolean HasDoneClassyThings{ get; set; };
 
-			[PREVIEW_API]
-			static DemoNamespace.Validator ObjectNameValdiator{ get; set; };
+		[DEFAULT_VALUE("DemoNamespace.CoolClass")]
+		[MUX_PROPERTY_CHANGED_CALLBACK]
+		String ObjectName{ get; set; };
+
+		event DemoNamespace.ValueChangedHandler<CoolClass, CoolClassNameChangedEventArgs> NameChanged;
+
+		static String NamespaceAlias{ get; };
+		static String ClassNameAlias{ get; };
+
+		[PREVIEW_API]
+		static DemoNamespace.Validator ObjectNameValdiator{ get; set; };
 	}
 
 	[PUBLIC_API]
 	[webhosthidden]
 	unsealed runtimeclass CoolClassNameChangedEventArgs : DemoNamespace.BaseEventArgs
 	{
-			CoolClassNameChangedEventArgs();
+		CoolClassNameChangedEventArgs();
 
-			[REQUIRE_NON_NULL]
-			String OldName{ get; set; };
+		[REQUIRE_NON_NULL]
+		String OldName{ get; set; };
 
-			[REQUIRE_NON_NULL]
-			String NewName{ get; set; };
+		[REQUIRE_NON_NULL]
+		String NewName{ get; set; };
 	}
 }

--- a/server/src/test/assets/large_demo_class.idl
+++ b/server/src/test/assets/large_demo_class.idl
@@ -1,0 +1,45 @@
+namespace DemoNamespace{
+
+	[PUBLIC_API]
+	[webhosthidden]
+	unsealed runtimeclass CoolClass : DemoNamespace.BaseClass
+	{
+			CoolClass();
+
+			// This should always return true...
+			Boolean IsCool{ get; };
+
+			[REQUIRE_NON_NULL]
+			CoolDemoNamespace.TemplateEngine TemplateEngine{ get; set; };
+			[REQUIRE_NON_NULL]
+			CoolDemoNamespace.Hashcode Hashcode{ get; set; };
+	
+			[PROPERTY_CHANGED_CALLBACK]
+			Boolean HasDoneClassyThings{ get; set; };
+	
+			[DEFAULT_VALUE("DemoNamespace.CoolClass")]
+			[MUX_PROPERTY_CHANGED_CALLBACK]
+			String ObjectName{ get; set; };
+
+			event DemoNamespace.ValueChangedHandler<CoolClass, CoolClassNameChangedEventArgs> NameChanged;
+	
+			static String NamespaceAlias{ get; };
+			static String ClassNameAlias{ get; };
+
+			[PREVIEW_API]
+			static DemoNamespace.Validator ObjectNameValdiator{ get; set; };
+	}
+
+	[PUBLIC_API]
+	[webhosthidden]
+	unsealed runtimeclass CoolClassNameChangedEventArgs : DemoNamespace.BaseEventArgs
+	{
+			CoolClassNameChangedEventArgs();
+
+			[REQUIRE_NON_NULL]
+			String OldName{ get; set; };
+
+			[REQUIRE_NON_NULL]
+			String NewName{ get; set; };
+	}
+}

--- a/server/src/test/assets/small_demo.idl
+++ b/server/src/test/assets/small_demo.idl
@@ -1,0 +1,9 @@
+namespace DemoNamespace
+{
+    runtimeclass DemoClass 
+    {
+        DemoClass();
+        Int32 DemoProperty{ get; set; };
+        Boolean IsDemoProperty(Int32 demoParameter);
+    }
+}

--- a/server/src/test/assets/small_demo.idl
+++ b/server/src/test/assets/small_demo.idl
@@ -1,9 +1,9 @@
 namespace DemoNamespace
 {
-    runtimeclass DemoClass 
-    {
-        DemoClass();
-        Int32 DemoProperty{ get; set; };
-        Boolean IsDemoProperty(Int32 demoParameter);
-    }
+	runtimeclass DemoClass 
+	{
+		DemoClass();
+		Int32 DemoProperty{ get; set; };
+		Boolean IsDemoProperty(Int32 demoParameter);
+	}
 }

--- a/server/src/test/parser.test.ts
+++ b/server/src/test/parser.test.ts
@@ -13,20 +13,30 @@ const grammarFile = fs.readFileSync(grammarFilePath).toString();
 const grammar = pegjs.generate(grammarFile);
 
 
+
 describe('Parser tests', async () => {
-  const goodIdlPath = process.env['GOOD_IDL_PATH']!;
+	const testCaseFolders = path.resolve(__dirname, '..', '..', 'src', 'test', 'assets');
 
-  it('Validate idl path', () => {
-    assert(goodIdlPath && goodIdlPath.length > 0, "Must set GOOD_IDL_PATH env var");
-    assert(fs.existsSync(goodIdlPath), `Path ${goodIdlPath} does not exist`);
+  it('Validate idl path for test cases', () => {
+    assert(fs.existsSync(testCaseFolders), `Path ${testCaseFolders} does not exist`);
   });
+	
+	runParserOnFolder(testCaseFolders);
 
-  const goodIdlFileSpec = path.join(goodIdlPath, '*.idl');
+	const goodIdlPath = process.env['GOOD_IDL_PATH']!;
+	if(fs.existsSync(goodIdlPath)){
+		runParserOnFolder(goodIdlPath);
+	}
+});
+
+
+function runParserOnFolder(folderPath: string){
+  const goodIdlFileSpec = path.join(folderPath, '*.idl');
 
   new glob.GlobSync(goodIdlFileSpec).found.forEach(idlPath => {
     const testName = path.basename(idlPath);
 
-    it(testName, async (done) => {
+    it("can parse file " + testName, async (done) => {
       const contents = fs.readFileSync(idlPath).toString();
       const tokens: IParsedToken[] = [];
       try {
@@ -39,4 +49,4 @@ describe('Parser tests', async () => {
       done();
     });
   });
-});
+}

--- a/server/src/test/parser.test.ts
+++ b/server/src/test/parser.test.ts
@@ -17,36 +17,36 @@ const grammar = pegjs.generate(grammarFile);
 describe('Parser tests', async () => {
 	const testCaseFolders = path.resolve(__dirname, '..', '..', 'src', 'test', 'assets');
 
-  it('Validate idl path for test cases', () => {
-    assert(fs.existsSync(testCaseFolders), `Path ${testCaseFolders} does not exist`);
-  });
-	
+	it('Validate idl path for test cases', () => {
+		assert(fs.existsSync(testCaseFolders), `Path ${testCaseFolders} does not exist`);
+	});
+
 	runParserOnFolder(testCaseFolders);
 
 	const goodIdlPath = process.env['GOOD_IDL_PATH']!;
-	if(fs.existsSync(goodIdlPath)){
+	if (fs.existsSync(goodIdlPath)) {
 		runParserOnFolder(goodIdlPath);
 	}
 });
 
 
-function runParserOnFolder(folderPath: string){
-  const goodIdlFileSpec = path.join(folderPath, '*.idl');
+function runParserOnFolder(folderPath: string) {
+	const goodIdlFileSpec = path.join(folderPath, '*.idl');
 
-  new glob.GlobSync(goodIdlFileSpec).found.forEach(idlPath => {
-    const testName = path.basename(idlPath);
+	new glob.GlobSync(goodIdlFileSpec).found.forEach(idlPath => {
+		const testName = path.basename(idlPath);
 
-    it("can parse file " + testName, async (done) => {
-      const contents = fs.readFileSync(idlPath).toString();
-      const tokens: IParsedToken[] = [];
-      try {
-        assert.doesNotThrow(() => grammar.parse(contents, { tokenList: tokens }));
-      } catch (e) {
-        done(e);
-        return;
-      }
-      assert.notStrictEqual(tokens.length, 0);
-      done();
-    });
-  });
+		it("can parse file " + testName, async (done) => {
+			const contents = fs.readFileSync(idlPath).toString();
+			const tokens: IParsedToken[] = [];
+			try {
+				assert.doesNotThrow(() => grammar.parse(contents, { tokenList: tokens }));
+			} catch (e) {
+				done(e);
+				return;
+			}
+			assert.notStrictEqual(tokens.length, 0);
+			done();
+		});
+	});
 }


### PR DESCRIPTION
This PR adds IDL files that can be used to check if the parser is still working.

Also, the server tests will test against those files as baseline and use the environment variable as added bonus.

In addition to that, I updated the `test:parser` script to also build the project for developer convenience.