### PR TITLE
Support protected constructors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "midl3-language-server",
-	"version": "0.0.30",
+	"version": "0.0.31",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "midl3-language-server",
-			"version": "0.0.30",
+			"version": "0.0.31",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"icon": "images/midl3.png",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
-	"version": "0.0.30",
+	"version": "0.0.31",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/asklar/midl-langserv"

--- a/server/src/midl.pegjs
+++ b/server/src/midl.pegjs
@@ -174,7 +174,7 @@ scopeBlock = _ attrHeader _ openBrace _ classMember* _ closeBrace
 
 fieldOrCtor = (field / ctor) _
 
-ctor "constructor" = _ attrHeader _ ctorName _ openParen _ methodDeclParams? _ closeParen _ ";"
+ctor "constructor" = _ attrHeader _ protectedKW? _ ctorName _ openParen _ methodDeclParams? _ closeParen _ ";"
 ctorName "ctor name" = identifier { return emit('method'); }
 
 requires = requiresKW _ listOfRequiresTypes

--- a/server/src/test/assets/protected_constructor.idl
+++ b/server/src/test/assets/protected_constructor.idl
@@ -1,0 +1,8 @@
+namespace DemoNamespace
+{
+  unsealed runtimeclass DemoClass
+  {
+    protected DemoClass();
+    protected DemoClass(String a);
+  }
+}


### PR DESCRIPTION
Previously, having a protected constructor broke syntax highlighting, despite MIDL actually being able to compile that. Fix this bug by supporting them.