### PR TITLE
Add support for uuid and interfaces deriving from each other

### DIFF
--- a/server/src/midl.pegjs
+++ b/server/src/midl.pegjs
@@ -116,7 +116,7 @@ attributeKW = "attributeKW" { return emit('keyword'); }
 attributeName "attribute name" = identifier { return emit('attribute')}
 
 /* INTERFACE DECL */
-ifaceDecl = _ "interface" _ interfaceName _ ((requires? _ openBrace _ ifaceMember* _ closeBrace) / ";") 
+ifaceDecl = _ "interface" _ interfaceName _ ((extends? _ requires? _ openBrace _ ifaceMember* _ closeBrace) / ";") 
 interfaceName = identifier { return emit('interface'); }
 
 /* METHOD DECL */

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -518,6 +518,8 @@ connection.onCompletion(
       'contract',
       'static_name',
       'attributeusage',
+      'contractversion',
+      'uuid',
       //
       'target_runtimeclass',
       'target_interface',

--- a/server/src/test/assets/interfaces.idl
+++ b/server/src/test/assets/interfaces.idl
@@ -10,6 +10,15 @@ namespace DemoNamespace
   {
     void DoSomething();
   }
+
+  [
+    uuid("12345678-1234-1234-1234-123456789012"),
+    contract(MyContract, 1.0)
+  ]
+  interface IMyInterface : Windows.Foundation.IInspectable
+  {
+      void Foo();
+  };
   
   runtimeclass DemoClass : [PREVIEW_API] /* comment */ IDemoInterface
   {


### PR DESCRIPTION
While it's not super common, people do say `interface IFoo : IInspectable` at times.

And they like to specify the `[uuid()]` on interfaces too.